### PR TITLE
Improving regex for extension parsing

### DIFF
--- a/src/main/scala/nl/anchormen/spark/cef/CefRelation.scala
+++ b/src/main/scala/nl/anchormen/spark/cef/CefRelation.scala
@@ -18,7 +18,7 @@ import java.io.PrintWriter
 object CefRelation{
   // regular expressions used to parse a CEF record and extension field
   val lineParser = "(.*(?<!\\\\))\\|(.*(?<!\\\\))\\|(.*(?<!\\\\))\\|(.*(?<!\\\\))\\|(.*(?<!\\\\))\\|(.*(?<!\\\\))\\|(.*(?<!\\\\))\\|(.*)".r
-  val extensionPattern = "([\\w|\\.|_|-]+)=(.+?)(?=$|\\s[\\w|\\.|_|-]+=)".r 
+  val extensionPattern = """(?m)([\w\._-]+)=(.+?)(?=$|\s[\w\._-]+=)""".r
 
   //val syslogDate = new SimpleDateFormat("yyyy MMM dd HH:mm:ss")
   


### PR DESCRIPTION
Thanks for your code. It's awesome!

I noticed a few issues with regex while doing unit testing.
1. I removed pipe characters (`|`) in character sets.
2. I turned on multiline match mode `(?m)` so that the positive look ahead matches end of string. I noticed that your positive look ahead expression had `$` but it doesn't get picked up by the look ahead group because it doesn't have a position. As a result, last extension key, value pairs are ignored.
3. Switched one double quotes to triple, so that you need to escape backslashes.